### PR TITLE
Add workaround for lower-case 'cookie' header

### DIFF
--- a/src/http/session/read.js
+++ b/src/http/session/read.js
@@ -8,7 +8,7 @@ var secret = process.env.ARC_APP_SECRET || process.env.ARC_APP_NAME || 'fallback
 module.exports = function _read(name, request, callback) {
 
   // adds request.session by cookie token lookup in dynamo
-  var jar = cookie.parse(request.headers && request.headers.Cookie? request.headers.Cookie || '': '')
+  var jar = cookie.parse(request.headers ? (request.headers.Cookie || request.headers.cookie || '') : '')
   var sesh = jar.hasOwnProperty('_idx')
   var valid = unsign(jar._idx || '', secret)
 


### PR DESCRIPTION
I'm not sure if it's browser specific or a change in API gateway/lambda, but at least for me the header name is "cookie" and not "Cookie"