### PR TITLE
Don't crash trying to read shared/.arc when runningLocally

### DIFF
--- a/src/http/helpers/_static.js
+++ b/src/http/helpers/_static.js
@@ -5,14 +5,14 @@ let arcFile = path.join(__dirname, '..', '..', '..', '..', 'shared', '.arc')
 let arc
 
 module.exports = function _static(assetPath) {
-  // only do this once
-  if (!arc) {
-    arc = parse(fs.readFileSync(arcFile).toString())
-  }
   // just passthru if we're not running in staging or production
   let runningLocally = process.env.NODE_ENV === 'testing'
   if (runningLocally) {
     return assetPath
+  }
+  // only do this once
+  if (!arc) {
+    arc = parse(fs.readFileSync(arcFile).toString())
   }
   // S3 is the oldest AWS service, and has a bit of cruft
   // if region is us-east-1, S3 paths are: http://s3.amazonaws.com/bucket


### PR DESCRIPTION
With the previous order, when running locally, `fs.readFileSync(arcFile)` will throw an error (since there is no `shared/.arc` on sandbox). Since we only use `arc` when not running locally this seems safe. But I'd love you to double check me here!