### PR TITLE
Fix static helper arc path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@architect/functions",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@architect/functions",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "architect run commands",
   "homepage": "https://github.com/arc-repos/arc-functions",
   "repository": {
@@ -30,13 +30,6 @@
     "api gateway",
     "framework"
   ],
-  "devDependencies": {
-    "aws-sdk": "^2.243.1",
-    "dynalite": "^1.3.1",
-    "eslint": "^5.1.0",
-    "tap-spec": "^5.0.0",
-    "tape": "^4.9.1"
-  },
   "dependencies": {
     "@architect/parser": "^1.1.0",
     "@smallwins/err": "^1.0.0",
@@ -49,6 +42,13 @@
     "run-waterfall": "^1.1.6",
     "serialize-error": "^2.1.0",
     "uid-safe": "^2.1.5"
+  },
+  "devDependencies": {
+    "aws-sdk": "^2.243.1",
+    "dynalite": "^1.3.1",
+    "eslint": "^5.1.0",
+    "tap-spec": "^5.0.0",
+    "tape": "^4.9.1"
   },
   "prettier": {
     "semi": false,

--- a/src/http/helpers/_static.js
+++ b/src/http/helpers/_static.js
@@ -1,7 +1,7 @@
 let fs = require('fs')
 let path = require('path')
 let parse = require('@architect/parser')
-let arcFile = path.join(__dirname, '..', '..', '..', '..', 'shared', '.arc')
+let arcFile = path.join(process.cwd(), 'node_modules', '@architect', 'shared', '.arc')
 let arc
 
 module.exports = function _static(assetPath) {


### PR DESCRIPTION
Fixes similar issue in `arc-functions` to `.arc` file path reading in `arc-data`, comments here: https://github.com/arc-repos/arc-data/pull/11#issue-244893756

This `arc-functions` fix published to NPM as `1.11.2@beta`
Similar `arc-data` fix now published to NPM as `2.0.11@beta`

---

Backup copy:
In the past we've had a number of concerns related to generating, placing, and retrieving `.arc` files in Functions, specifically with differentiations accounting for Function filesystem generation (i.e. `sandbox` vs. `deploy` vs. `hydrate`) and environments (`sandbox` vs. real Lambdas).

These have had an influence in how a Function's `.arc` file could be found by libraries such as `arc-data` and `arc-functions`.

Fortunately, this got dried up a lot recently, and is now much more deterministic due to two factors:

- `sandbox` "2.0" (Arc 4.3) spawns child processes, which mean we can find files with the same `process.cwd()` logic we often rely on in real Lambdae
- The hydrate API (Arc 4.5) now consistently populates the `.arc` file in all Functions at all times, whereas before that file may not have always been accessible (which necessitated searching in the main project directory for `sandbox`)

This means that `sandbox` and real Lambda can always rely on the same effective call to find a Function's `.arc` file: `process.cwd() + /node_modules/@architect/shared/.arc`

---

## Background

Here's [how `.arc` used to be found by `arc-data`](https://github.com/arc-repos/arc-data/blob/64de95b9a6f1eedc236b8b95c29cfecd485f56ab/index.js).

In Arc 4, changes to `sandbox` + `ARC_LOCAL` meant `process.cwd() + /.arc` no longer worked, so we had to add a checks for `process.cwd() + /node_modules/@architect/shared/.arc`

However, this change was only scoped to `ARC_LOCAL` env flags, which meant that `sandbox` + `arc-data|functions` users that didn't use `ARC_LOCAL` weren't able to find the correct file.

---

## Old way
- if `ARC_LOCAL` env var is present:
  - first: `process.cwd() + /node_modules/@architect/shared/.arc`
    - The only way to find `.arc` that is both `sandbox` + real Lambda compatible
  - then: `process.cwd() + /.arc`
- then try the current working directory:
  - `process.cwd() + /.arc`
    - (works in Lambda, breaks in `sandbox`)
- then try relative path based on `arc-data`:
  - effectively: `/absolute/path/to/project/src/http/get-index/node_modules/@architect/arc-data/../shared/.arc`)
    - (works in Lambda, breaks in `sandbox`)

`ARC_LOCAL` should not be a requirement for running `sandbox`; additionally, this logic is redundant and overwrought. Update suggested by @mikemaccana...

## Update
- first, rely on `process.cwd() + /node_modules/@architect/shared/.arc`
  - works in Lambda, works in Sandbox (with or without `ARC_LOCAL`)
  - presumably only Arc 3.x `sandbox` users get any further than this
- then try the current working directory (legacy):
  - `process.cwd() + /.arc`
- then try relative path based on `arc-data` (legacy)
  - `/absolute/path/to/project/src/http/get-index/node_modules/@architect/arc-data/../shared/.arc`