### PR TITLE
align cookie Expires/Max-Age attributes

### DIFF
--- a/src/http/providers/ddb.js
+++ b/src/http/providers/ddb.js
@@ -64,10 +64,10 @@ function write(params, callback) {
       callback(err)
     }
     else {
-      let maxAge = Date.now() + 7.884e+11
+      let maxAge = 7.884e+8
       let result = cookie.serialize('_idx', sign(params._idx, secret), {
         maxAge,
-        expires: new Date(maxAge),
+        expires: new Date(Date.now() + maxAge * 1000),
         secure: true,
         httpOnly: true,
         path: '/',

--- a/src/http/providers/jwe.js
+++ b/src/http/providers/jwe.js
@@ -36,10 +36,10 @@ function read(req) {
 function write(payload) {
   let key = '_idx'
   let val = jwe.create(payload)
-  let maxAge = Date.now() + 7.884e+11
+  let maxAge = 7.884e+8
   return cookie.serialize(key, val, {
     maxAge,
-    expires: new Date(maxAge),
+    expires: new Date(Date.now() + maxAge * 1000),
     secure: true,
     httpOnly: true,
     path: '/',

--- a/src/http/session/write.js
+++ b/src/http/session/write.js
@@ -14,10 +14,10 @@ module.exports = function _write(name, params, callback) {
       console.log(err)
       throw err
     }
-    var maxAge = Date.now() + 7.884e+11
+    var maxAge = 7.884e+8
     cmds.cookie = cookie.serialize('_idx', sign(request._idx, secret), {
       maxAge,
-      expires: new Date(maxAge),
+      expires: new Date(Date.now() + maxAge * 1000),
       secure: true,
       httpOnly: true,
       path: '/',


### PR DESCRIPTION
`Max-Age` attribute represents number of seconds until the cookie expires, not date of expiry [in milliseconds since epoch]. In modern browsers, because `Max-Age` supersedes `Expiry` – which is, presumably, being set as intended – cookies are set with expirations ridiculously far into the future (the year 76020, currently).