### PR TITLE
Minor fix: queue/publish local conditional

### DIFF
--- a/src/queues/_publish.js
+++ b/src/queues/_publish.js
@@ -37,7 +37,7 @@ module.exports = function _publish(params, callback) {
   }
 
   // check if we're running locally
-  let local = process.env.NODE_ENV === 'testing' && !process.env.hasOwnProperty('ARC_LOCAL')
+  let local = process.env.NODE_ENV === 'testing' || !process.env.hasOwnProperty('ARC_LOCAL')
   if (local) {
 
     // if so send the mock request


### PR DESCRIPTION
# What does this PR do?

Fixes the conditional to honor `ARC_LOCAL` so that `arc.queues.publish` works as expected when running from `sandbox`.

Behavior is consistent with [arc.event.publish](https://github.com/arc-repos/arc-functions/blob/master/src/events/_publish.js#L60).